### PR TITLE
Bugfix/multiple object type support

### DIFF
--- a/Custom_Meta/Custom_Meta_Box.php
+++ b/Custom_Meta/Custom_Meta_Box.php
@@ -24,30 +24,45 @@ abstract class Custom_Meta_Box {
 	 */
 	protected $metabox = null;
 
+	/**
+	 * Object types.
+	 * 
+	 * @var array
+	 */
+	protected $object_types = [];
 
-	function __construct( string $id, string $field_prefix = '' ) {
+	/**
+	 * Taxonomies.
+	 * 
+	 * @var array
+	 */
+	protected $taxonomies = [];
+
+	function __construct( string $id, string $field_prefix = '', array $object_types = [], array $taxonomies = [] ) {
 		$this->id = $id;
 		$this->field_prefix = ( $field_prefix ) ? $field_prefix . '-' : '';
+		$this->object_types = $this->get_prefixed_object_types( $object_types );
+		$this->taxonomies = $taxonomies;
 	}
 
 	/**
 	 * Creates a custom metabox.
 	 *
-	 * @param array $post_types Post types in which the custom metabox should
+	 * @param array $object_types Post types or object types (term, user, comment, options-page) in which the custom metabox should
 	 *                          be displayed.
+	 * @param array $taxonomies Taxonomies in which the metabox should be displayed, if object type is 'term'
 	 * @return Object Custom metabox object.
 	 */
-	abstract protected function create( array $post_types );
+	abstract protected function create();
 
 	/**
-	 * Adds the custom metabox to set of post types.
+	 * Adds the custom metabox to set of post types, terms, user or options-page.
 	 *
-	 * @param  Object $metabox      Metabox object.
 	 * @param  array  $object_types Name of the object type for the custom meta
 	 *                              box. Object-types can be built-in Post Type
 	 *                              or any Custom Post Type that may be registered.
 	 */
-	protected function set_object_types( $metabox, array $object_types ) {
+	protected function get_prefixed_object_types( array $object_types ) {
 
 		// Convert the object types to strings because it can be a list of
 		// strings or a list of post type objects.
@@ -60,7 +75,7 @@ abstract class Custom_Meta_Box {
 			}
 		}, $object_types );
 
-		$metabox->set_prop( 'object_types', $object_types_slugs );
+		return $object_types_slugs;
 	}
 
 }

--- a/Custom_Meta/Custom_Meta_Box.php
+++ b/Custom_Meta/Custom_Meta_Box.php
@@ -48,9 +48,6 @@ abstract class Custom_Meta_Box {
 	/**
 	 * Creates a custom metabox.
 	 *
-	 * @param array $object_types Post types or object types (term, user, comment, options-page) in which the custom metabox should
-	 *                          be displayed.
-	 * @param array $taxonomies Taxonomies in which the metabox should be displayed, if object type is 'term'
 	 * @return Object Custom metabox object.
 	 */
 	abstract protected function create();

--- a/Custom_Meta/Custom_Meta_Box_Builder.php
+++ b/Custom_Meta/Custom_Meta_Box_Builder.php
@@ -9,6 +9,8 @@ class Custom_Meta_Box_Builder {
 	 * @param  string $id           Custom meta box identifier.
 	 * @param  string $name         Custom meta box name.
 	 * @param  string $field_prefix Field prefix.
+	 * @param  array  $object_types Object types for this meta box.
+	 * @param  array  $taxonomies   Taxonomies for this meta box (used if object type is 'term')
 	 * @return object The custom meta object that was built.
 	 */
 	public function build( string $id, string $name, string $field_prefix = '', array $object_types = [], array $taxonomies = [] ) {

--- a/Custom_Meta/Custom_Meta_Box_Builder.php
+++ b/Custom_Meta/Custom_Meta_Box_Builder.php
@@ -11,14 +11,14 @@ class Custom_Meta_Box_Builder {
 	 * @param  string $field_prefix Field prefix.
 	 * @return object The custom meta object that was built.
 	 */
-	public function build( string $id, string $name, string $field_prefix = '' ) {
+	public function build( string $id, string $name, string $field_prefix = '', array $object_types = [], array $taxonomies = [] ) {
 		$classname = __NAMESPACE__ . "\\" . $name;
 
 		if ( ! class_exists( $classname ) ) {
 			return new \WP_Error( 'invalid-custom-meta', __( 'The custom meta box you attempting to create does not have a class to instance. Possible problems: your configuration does not match the class file name; the class file name does not exist.', 'zf-features' ), $classname );
 		}
 
-		return new $classname( $id, $field_prefix );
+		return new $classname( $id, $field_prefix, $object_types, $taxonomies );
 	}
 
 }

--- a/Custom_Meta/Location.php
+++ b/Custom_Meta/Location.php
@@ -9,9 +9,6 @@ class Location extends Custom_Meta_Box {
 	/**
 	 * Creates the Location metabox.
 	 *
-	 * @param array $object_types Object types in which the Location metabox should
-	 *                          be displayed.
-	 * @param array $taxonomies Taxonomies in which the metabox should be displayed, if object type is 'term'
 	 * @return Location Metabox object.
 	 */
 	public function create() {

--- a/Custom_Meta/Location.php
+++ b/Custom_Meta/Location.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * An example metabox.
+ */
 namespace ZF_Features\Custom_Meta;
 
 class Location extends Custom_Meta_Box {
@@ -6,17 +9,19 @@ class Location extends Custom_Meta_Box {
 	/**
 	 * Creates the Location metabox.
 	 *
-	 * @param array $post_types Post types in which the Location metabox should
+	 * @param array $object_types Object types in which the Location metabox should
 	 *                          be displayed.
+	 * @param array $taxonomies Taxonomies in which the metabox should be displayed, if object type is 'term'
 	 * @return Location Metabox object.
 	 */
-	public function create( array $post_types = array() ) {
+	public function create() {
 
 		// Initiate the metabox.
 		$this->metabox = new \CMB2( array(
-			'id'           => $this->id,
+			'id'           => $this->id, // set via app-config.php
 			'title'        => __( 'Location', 'zf-features' ),
-			'object_types' => [],
+			'object_types' => $this->object_types, // set via app-config.php
+			'taxonomies'   => $this->taxonomies, // set via app-config.php
 			'context'      => 'normal',
 			'priority'     => 'high',
 			'show_names'   => true, // Show field names on the left
@@ -35,8 +40,6 @@ class Location extends Custom_Meta_Box {
 			'id'         => $this->field_prefix . 'lng',
 			'type'       => 'text',
 		) );
-
-		$this->set_object_types( $this->metabox, $post_types );
 
 		return $this;
 	}

--- a/app-config.php
+++ b/app-config.php
@@ -19,9 +19,10 @@ return [
 	// Custom meta boxes.
 	'cmb' => [
 		'location' => [
-			'name'       => 'Location',
-			'post_types' => [ 'thing' ],
-		],
+			'name'         => 'Location',
+			'object_types' => [ 'thing' ], // an array of post types, or 'term', 'comment', 'user', 'options-page'
+			// 'taxonomies' => [ 'taxonomy_name' ] // if object_type is 'term', specify taxonomies
+		]
 	],
 	// Views.
 	'views' => [


### PR DESCRIPTION
Adding support for all object types supported by CMB2

* Added `object_types` and `taxonomies` as properties of `Custom_Meta_Box`, slightly simplifying meta box creation. Now the create method no longer takes post / object types as a parameter but simply gets the properties $this->object_types and $this->taxonomies which are set by the builder class.
* Support a `taxonomies` array when defining meta boxes in app-config.php
* Replaced set_object_types method with get_prefixed_object_types which simply returns the array of object types, prefixed if necessary.

Tested with taxonomies and post types.

TODO: test with users, comments and options pages.
